### PR TITLE
Fixes from first review

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "aligned"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +519,8 @@ dependencies = [
  "ron",
  "serde",
  "thiserror 1.0.69",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2089,6 +2100,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "lebe"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2201,6 +2218,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -2437,6 +2463,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
  "bitflags 2.10.0",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3282,6 +3317,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+
+[[package]]
 name = "renderdoc-sys"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3477,6 +3529,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -3736,6 +3797,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tiff"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3844,6 +3914,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3935,6 +4035,12 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,5 @@ eframe = "0.33"
 egui = "0.33"
 rfd = "0.17"
 image = "0.25"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }

--- a/examples/melody.rs
+++ b/examples/melody.rs
@@ -79,4 +79,3 @@ fn run<T: cpal::SizedSample + cpal::FromSample<f32>>(
         std::thread::sleep(std::time::Duration::from_millis(10));
     }
 }
-

--- a/examples/midi_debug.rs
+++ b/examples/midi_debug.rs
@@ -65,4 +65,3 @@ fn print_midi(timestamp: u64, msg: &[u8]) {
         }
     }
 }
-

--- a/examples/virtual_keyboard.rs
+++ b/examples/virtual_keyboard.rs
@@ -112,4 +112,3 @@ enum NoteEvent {
     NoteOn(f32),
     NoteOff,
 }
-

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -7,5 +7,17 @@ pub use track::{NotePlaybackState, PlaybackState, TrackConfig};
 pub use voice::{ADSRConfig, EnvelopeState, NoteState};
 
 pub fn midi_to_freq(note: u8) -> f32 {
+    // Multiplying any frequency by 2 makes it one octave (12 semi-tones) higher
+    // so we can find the frequency that is exactly 1 semi-tone higher by
+    // multiplying by 2 raised to the power 1/12. More generally, starting from
+    // any given frequency, we can find the frequency that is exactly X semi-
+    // tones higher by multiplying is by 2.pow(X / 12).
+    //
+    // This works in both directions: if we want to find a frequency that is X
+    // semi-tones lower we can multiply by 2.pow(-X / 12)
+    //
+    // by starting from A4 (semi-tone 69 in MIDI and with a frequency of 440Hz)
+    // we can find the frequency of the midi note `note` using this formula:
+
     440.0 * 2.0_f32.powf((note as f32 - 69.0) / 12.0)
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -427,17 +427,16 @@ fn process_event(
     event: &events::ScheduledEvent,
 ) {
     match &event.event {
-        events::Event::MidiEvent {
-            track_id,
-            pitch,
-            velocity,
-            is_note_on,
-        } => {
-            if *track_id < playback_states.len() {
-                if *is_note_on {
+        events::Event::MidiEvent { track_id, message } => {
+            if *track_id >= playback_states.len() {
+                return;
+            }
+            match message {
+                events::MidiMessage::NoteOn { pitch, velocity } => {
                     let num_oscs = configs.get(*track_id).map_or(0, |c| c.num_oscillators());
                     playback_states[*track_id].note_on(*pitch, *velocity, num_oscs);
-                } else {
+                }
+                events::MidiMessage::NoteOff { pitch } => {
                     playback_states[*track_id].note_off(*pitch);
                 }
             }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -69,7 +69,7 @@ fn engine_thread(command_rx: Receiver<EngineCommand>, update_tx: Sender<EngineUp
     };
 
     loop {
-        match command_rx.recv_timeout(std::time::Duration::from_millis(50)) {
+        match command_rx.recv() {
             Ok(EngineCommand::LoadProject(path)) => match Project::load(&path) {
                 Ok(project) => {
                     println!("Project loaded successfully");
@@ -161,10 +161,7 @@ fn engine_thread(command_rx: Receiver<EngineCommand>, update_tx: Sender<EngineUp
                 // TODO
             }
 
-            Err(crossbeam::channel::RecvTimeoutError::Timeout) => {
-                // Timeout - continue to send updates
-            }
-            Err(crossbeam::channel::RecvTimeoutError::Disconnected) => break,
+            Err(crossbeam::channel::RecvError) => break,
         }
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -5,12 +5,16 @@ pub struct ScheduledEvent {
 }
 
 #[derive(Debug, Clone)]
+pub enum MidiMessage {
+    NoteOn { pitch: u8, velocity: u8 },
+    NoteOff { pitch: u8 },
+}
+
+#[derive(Debug, Clone)]
 pub enum Event {
     MidiEvent {
         track_id: usize,
-        pitch: u8,
-        velocity: u8,
-        is_note_on: bool,
+        message: MidiMessage,
     },
     StopAllNotes {
         track_id: usize,
@@ -19,10 +23,4 @@ pub enum Event {
         track_id: usize,
         new_node_id: String,
     },
-}
-
-#[derive(Debug, Clone)]
-pub enum MidiMessage {
-    NoteOn { pitch: u8, velocity: u8 },
-    NoteOff { pitch: u8 },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use aurio::{AurioApp, spawn_engine};
-use tracing_subscriber::{EnvFilter, fmt};
+use tracing_subscriber::EnvFilter;
 
 fn main() {
     tracing_subscriber::fmt()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,13 @@
 use aurio::{AurioApp, spawn_engine};
+use tracing_subscriber::{EnvFilter, fmt};
 
 fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
+
     let engine = spawn_engine();
 
     let icon_image = image::open("assets/icon.png")

--- a/src/scripting/variables.rs
+++ b/src/scripting/variables.rs
@@ -14,6 +14,12 @@ pub struct VariableStore {
     global_vars: HashMap<String, LuaValue>,                // var_name
 }
 
+impl Default for VariableStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl VariableStore {
     pub fn new() -> Self {
         Self {

--- a/src/timing/mod.rs
+++ b/src/timing/mod.rs
@@ -2,6 +2,6 @@ mod scheduler;
 mod sequence;
 mod state_machine;
 
-pub use scheduler::{schedule_sequence_events, EventProducer, SchedulerError};
+pub use scheduler::{EventProducer, SchedulerError, schedule_sequence_events};
 pub use sequence::{GeneratedPattern, Note, Sequence, StaticPattern};
 pub use state_machine::{Edge, Hook, Node, StateGraph, TransitionTiming};

--- a/src/timing/scheduler.rs
+++ b/src/timing/scheduler.rs
@@ -13,10 +13,8 @@ pub fn schedule_sequence_events(
     producer: &mut EventProducer,
     lua_runtime: Option<&crate::scripting::LuaRuntime>,
 ) -> Result<(), SchedulerError> {
-    let notes = match sequence {
-        Sequence::Static(pattern) => pattern.notes.clone(),
-        Sequence::Generated(_pattern) => sequence.get_notes(lua_runtime),
-    };
+    // Invariant: there is no overlap of notes of the same pitch
+    let notes = sequence.get_notes(lua_runtime);
 
     let samples_per_beat = (60.0 / bpm) * sample_rate;
     let sequence_duration = sequence.duration_samples(bpm, sample_rate) as u64;

--- a/src/timing/scheduler.rs
+++ b/src/timing/scheduler.rs
@@ -1,5 +1,5 @@
 use super::Sequence;
-use crate::events::{Event, ScheduledEvent};
+use crate::events::{Event, MidiMessage, ScheduledEvent};
 use ringbuf::traits::Producer;
 
 pub type EventProducer = ringbuf::HeapProd<ScheduledEvent>;
@@ -31,9 +31,10 @@ pub fn schedule_sequence_events(
                 sample_timestamp: note_on_sample,
                 event: Event::MidiEvent {
                     track_id,
-                    pitch: note.pitch,
-                    velocity: note.velocity,
-                    is_note_on: true,
+                    message: MidiMessage::NoteOn {
+                        pitch: note.pitch,
+                        velocity: note.velocity,
+                    },
                 },
             });
         }
@@ -46,9 +47,7 @@ pub fn schedule_sequence_events(
                 sample_timestamp: note_off_sample,
                 event: Event::MidiEvent {
                     track_id,
-                    pitch: note.pitch,
-                    velocity: note.velocity,
-                    is_note_on: false,
+                    message: MidiMessage::NoteOff { pitch: note.pitch },
                 },
             });
         }

--- a/src/timing/sequence.rs
+++ b/src/timing/sequence.rs
@@ -89,8 +89,8 @@ impl Sequence {
                 if let Some(runtime) = lua_runtime {
                     runtime
                         .execute_pattern(&pattern.function)
-                        .unwrap_or_else(|e| {
-                            eprintln!("Lua error: {}", e);
+                        .unwrap_or_else(|err| {
+                            tracing::error!(err = %err, "Lua error");
                             Vec::new()
                         })
                 } else {

--- a/src/timing/state_machine.rs
+++ b/src/timing/state_machine.rs
@@ -40,6 +40,12 @@ pub struct StateGraph {
     pub edges: Vec<Edge>,
 }
 
+impl Default for StateGraph {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl StateGraph {
     pub fn new() -> Self {
         Self {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -91,7 +91,7 @@ impl AurioApp {
                         match project.save(path) {
                             Ok(_) => {
                                 self.project_modified = false;
-                                println!("Project saved successfully");
+                                tracing::info!(path = %path.display(), "Project saved successfully");
                             }
                             Err(e) => {
                                 self.error_message = Some(format!("Failed to save project: {}", e));

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -258,24 +258,13 @@ impl eframe::App for AurioApp {
         let mut modified_pattern: Option<(usize, String, StaticPattern)> = None;
 
         let piano_roll_data: Option<(usize, String, StaticPattern, String)> =
-            if let Some((track_id, node_id)) = &self.selected_node {
-                if let Some(ref project) = self.current_project {
-                    if let Some(track) = project.tracks.iter().find(|t| t.id == *track_id) {
-                        if let Some(node) = track.graph.get_node(node_id) {
-                            if let Sequence::Static(pattern) = &node.sequence {
-                                Some((*track_id, node_id.clone(), pattern.clone(), node.id.clone()))
-                            } else {
-                                None
-                            }
-                        } else {
-                            None
-                        }
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                }
+            if let Some((track_id, node_id)) = &self.selected_node
+                && let Some(ref project) = self.current_project
+                && let Some(track) = project.tracks.iter().find(|t| t.id == *track_id)
+                && let Some(node) = track.graph.get_node(&node_id)
+                && let Sequence::Static(pattern) = &node.sequence
+            {
+                Some((*track_id, node_id.clone(), pattern.clone(), node.id.clone()))
             } else {
                 None
             };
@@ -308,18 +297,16 @@ impl eframe::App for AurioApp {
                 });
         }
 
-        if let Some((track_id, node_id, new_pattern)) = modified_pattern {
-            if let Some(ref mut project) = self.current_project {
-                if let Some(track) = project.tracks.iter_mut().find(|t| t.id == track_id) {
-                    if let Some(node) = track.graph.nodes.iter_mut().find(|n| n.id == node_id) {
-                        node.sequence = Sequence::Static(new_pattern);
-                        let _ = self
-                            .engine
-                            .command_tx
-                            .send(EngineCommand::ReloadProject(project.clone()));
-                    }
-                }
-            }
+        if let Some((track_id, node_id, new_pattern)) = modified_pattern
+            && let Some(ref mut project) = self.current_project
+            && let Some(track) = project.tracks.iter_mut().find(|t| t.id == track_id)
+            && let Some(node) = track.graph.nodes.iter_mut().find(|n| n.id == node_id)
+        {
+            node.sequence = Sequence::Static(new_pattern);
+            let _ = self
+                .engine
+                .command_tx
+                .send(EngineCommand::ReloadProject(project.clone()));
         }
 
         if close_piano_roll {
@@ -348,18 +335,18 @@ impl eframe::App for AurioApp {
 
             egui::CentralPanel::default().show(ctx, |ui| {
                 if let Some(track_idx) = self.selected_track {
-                    if let Some(ref project) = self.current_project {
-                        if let Some(track) = project.tracks.get(track_idx) {
-                            ui.heading(format!("Graph: {}", track.name));
-                            ui.label(format!("BPM: {}", project.bpm));
-                            if let Some(current) = self.current_nodes.get(&track.id) {
-                                ui.label(format!("▶ Currently playing: {}", current));
-                            }
-                            ui.separator();
-
-                            let track_clone = track.clone();
-                            self.draw_graph(ui, &track_clone);
+                    if let Some(ref project) = self.current_project
+                        && let Some(track) = project.tracks.get(track_idx)
+                    {
+                        ui.heading(format!("Graph: {}", track.name));
+                        ui.label(format!("BPM: {}", project.bpm));
+                        if let Some(current) = self.current_nodes.get(&track.id) {
+                            ui.label(format!("▶ Currently playing: {}", current));
                         }
+                        ui.separator();
+
+                        let track_clone = track.clone();
+                        self.draw_graph(ui, &track_clone);
                     }
                 } else {
                     ui.vertical_centered(|ui| {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -65,8 +65,8 @@ impl AurioApp {
                     ui.close();
                 }
 
-                if ui.button("Open Project...").clicked() {
-                    if let Some(path) = rfd::FileDialog::new()
+                if ui.button("Open Project...").clicked()
+                    && let Some(path) = rfd::FileDialog::new()
                         .set_title("Open Aurio Project")
                         .pick_folder()
                     {
@@ -77,7 +77,6 @@ impl AurioApp {
                             .send(EngineCommand::LoadProject(path));
                         ui.close();
                     }
-                }
 
                 let save_button = if self.project_modified {
                     ui.button("💾 Save Project *")
@@ -126,10 +125,8 @@ impl AurioApp {
                 if ui.button("⏸ Pause").clicked() {
                     let _ = self.engine.command_tx.send(EngineCommand::Pause);
                 }
-            } else {
-                if ui.button("▶ Play").clicked() {
-                    let _ = self.engine.command_tx.send(EngineCommand::Play);
-                }
+            } else if ui.button("▶ Play").clicked() {
+                let _ = self.engine.command_tx.send(EngineCommand::Play);
             }
 
             if ui.button("⏹ Stop").clicked() {
@@ -222,13 +219,11 @@ impl AurioApp {
                 egui::Color32::LIGHT_GRAY,
             );
 
-            if response.clicked() {
-                if let Some(click_pos) = response.interact_pointer_pos() {
-                    if rect.contains(click_pos) {
+            if response.clicked()
+                && let Some(click_pos) = response.interact_pointer_pos()
+                    && rect.contains(click_pos) {
                         self.selected_node = Some((track.id, node.id.clone()));
                     }
-                }
-            }
         }
     }
 }
@@ -261,7 +256,7 @@ impl eframe::App for AurioApp {
             if let Some((track_id, node_id)) = &self.selected_node
                 && let Some(ref project) = self.current_project
                 && let Some(track) = project.tracks.iter().find(|t| t.id == *track_id)
-                && let Some(node) = track.graph.get_node(&node_id)
+                && let Some(node) = track.graph.get_node(node_id)
                 && let Sequence::Static(pattern) = &node.sequence
             {
                 Some((*track_id, node_id.clone(), pattern.clone(), node.id.clone()))
@@ -274,7 +269,7 @@ impl eframe::App for AurioApp {
             let state = self
                 .piano_roll_states
                 .entry(state_key)
-                .or_insert_with(PianoRollState::default);
+                .or_default();
             if state.vertical_zoom == 20.0 && state.horizontal_zoom == 50.0 {
                 state.fit_to_pattern(&pattern, egui::Vec2::new(800.0, 300.0));
             }

--- a/src/ui/piano_roll.rs
+++ b/src/ui/piano_roll.rs
@@ -313,13 +313,11 @@ impl<'a> PianoRoll<'a> {
                 egui::StrokeKind::Inside,
             );
 
-            if response.secondary_clicked() {
-                if let Some(click_pos) = response.interact_pointer_pos() {
-                    if note_rect.contains(click_pos) {
+            if response.secondary_clicked()
+                && let Some(click_pos) = response.interact_pointer_pos()
+                    && note_rect.contains(click_pos) {
                         note_to_delete = Some(idx);
                     }
-                }
-            }
         }
 
         if let Some(idx) = note_to_delete {
@@ -327,9 +325,9 @@ impl<'a> PianoRoll<'a> {
             modification = Some(NoteModification::Deleted);
         }
 
-        if response.clicked() {
-            if let Some(click_pos) = response.interact_pointer_pos() {
-                if click_pos.x > rect.left() + piano_key_width {
+        if response.clicked()
+            && let Some(click_pos) = response.interact_pointer_pos()
+                && click_pos.x > rect.left() + piano_key_width {
                     let pitch = self.screen_y_to_pitch(click_pos.y, rect);
                     let beat = self.screen_x_to_beat(click_pos.x, rect, piano_key_width);
 
@@ -357,8 +355,6 @@ impl<'a> PianoRoll<'a> {
                         }
                     }
                 }
-            }
-        }
 
         modification
     }


### PR DESCRIPTION
Thanks for the review @ChronosWS, I tried to address each message in a separate commit to make it easy to check again.

- b42afef: Added a comment to explain the `midi_to_freq()` function
- 16e3e76: It's true I don't need the velocity for `NoteOff`. I actually already had an unused enum `MidiMessage` that reflected that correctly. I am now using that in a `message` field of `MidiEvent` instead of the ugly `is_note_on: bool`
- 3363f56: I've added a normalization step in `Sequence::get_notes` that ensures there is no overlapping notes with the same pitch (overlapping notes are merged)
- 82f1a38: Use let chains (part 1)
- 65946b6: use `recv` instead of `recv_timeout`. I had a misunderstanding that it would be preferrable to use `recv_timeout` so that if after some time no message was received, we just iterate on empty but actually that was dumb: we're already in a separate thread, + looping on empty or blocking would be the same thing anyway
- bdf4492: Use tracing instead of print